### PR TITLE
Remove check on "lonely_pawns" in semistatic [is_unwinnable] routine - Fixes #37

### DIFF
--- a/src/semistatic.cpp
+++ b/src/semistatic.cpp
@@ -288,7 +288,7 @@ Bitboard SemiStatic::System::visitors(Position& pos, Bitboard region, Color c) {
 }
 
 bool SemiStatic::System::is_unwinnable(Position& pos, Color intendedWinner) {
-  if (UTIL::has_lonely_pawns(pos)) return false;
+  // if (UTIL::has_lonely_pawns(pos)) return false;
 
   Bitboard loserKingRegion = king_region(pos, ~intendedWinner);
   Bitboard visitors =

--- a/tests/test.output
+++ b/tests/test.output
@@ -28,12 +28,12 @@ POSITIONS COUNT:
      solved: 3628/3652
    unsolved: 24
  pre-static: 1159
-     static: 1066
-post-static: 1403
+     static: 1115
+post-static: 1354
 
 NODES COUNT:
-total nodes: 480721667
-nodes (avg): 131632
+total nodes: 479216771
+nodes (avg): 131220
 nodes (max): 10914388
 
 ---------------- Test Lichess ----------------


### PR DESCRIPTION
Some positions contain lonely pawns and are statically unwinnable. See Issue #37.